### PR TITLE
Fix file compression in upload-file sub command

### DIFF
--- a/pkg/core/file.go
+++ b/pkg/core/file.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"bufio"
 	"errors"
 	"io"
 	"io/ioutil"
@@ -9,6 +8,7 @@ import (
 	"path/filepath"
 
 	gzip "github.com/klauspost/pgzip"
+
 	"github.com/hatena/u2s3/pkg/config"
 	"github.com/hatena/u2s3/pkg/util"
 )
@@ -145,13 +145,14 @@ func (f *File) compress() error {
 	} else {
 		in = inFp
 	}
-	scanner := bufio.NewScanner(in)
-	gw, _ := gzip.NewWriterLevel(outFp, gzip.BestCompression)
-	w := bufio.NewWriter(gw)
-	for scanner.Scan() {
-		w.Write(scanner.Bytes())
+	gw, err := gzip.NewWriterLevel(outFp, gzip.BestCompression)
+	if err != nil {
+		return err
 	}
-	w.Flush()
+	_, err = io.Copy(gw, in)
+	if err != nil {
+		return err
+	}
 	gw.Close()
 	outFp.Close()
 	return nil

--- a/pkg/core/file_test.go
+++ b/pkg/core/file_test.go
@@ -1,0 +1,38 @@
+package core
+
+import (
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+
+	gzip "github.com/klauspost/pgzip"
+)
+
+func TestFileCompress(t *testing.T) {
+	contents := []byte("abc\ndef\nghi")
+	src, err := ioutil.TempFile("", "u2s3")
+	if err != nil {
+		t.Fatalf("error: %s", err)
+	}
+	src.Write(contents)
+	src.Close()
+	defer os.Remove(src.Name())
+	f := NewFile(src.Name(), "", "", "")
+	if err := f.compress(); err != nil {
+		t.Fatalf("error: %s", err)
+	}
+	out := f.GetFile()
+	defer os.Remove(out.Name())
+	outRaw, err := gzip.NewReader(out)
+	if err != nil {
+		t.Fatalf("error: %s", err)
+	}
+	got, err := ioutil.ReadAll(outRaw)
+	if err != nil {
+		t.Fatalf("error: %s", err)
+	}
+	if !reflect.DeepEqual(contents, got) {
+		t.Errorf("contents mismatch: %s, %s", contents, got)
+	}
+}


### PR DESCRIPTION
`u2s3 upload-file` has a bug that it removes the new lines (`u2s3 upload-log` is ok). This pull request fixes the bug and added a test for the case.