### PR TITLE
upload-log: support jsonl log format

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -28,7 +28,7 @@ var commands = []cli.Command{
 		Action: uploadLogCmd,
 		Flags: append(commonFlags,
 			cli.IntFlag{Name: "s, step", Value: 30, Usage: "step for splitting logs. (min)"},
-			cli.StringFlag{Name: "l, log-format", Value: "tsv", Usage: "tsv or ssv (default: tsv)"},
+			cli.StringFlag{Name: "l, log-format", Value: "tsv", Usage: "tsv, ssv or jsonl (default: tsv)"},
 		),
 	},
 	{

--- a/pkg/core/epoch.go
+++ b/pkg/core/epoch.go
@@ -9,13 +9,14 @@ import (
 	"regexp"
 	"time"
 
-	gzip "github.com/klauspost/pgzip"
 	"github.com/hatena/u2s3/pkg/config"
 	"github.com/hatena/u2s3/pkg/input/content"
 	"github.com/hatena/u2s3/pkg/util"
+	gzip "github.com/klauspost/pgzip"
 )
 
 var reTsv = regexp.MustCompile(`(?:^|[ \t])time\:([^\t]+)`)
+var reJsonl = regexp.MustCompile(`"time"\s*\:\s*"([^"]+)`)
 
 type EpochAggregator struct {
 	reader content.BufferedReader
@@ -127,6 +128,11 @@ func parseEpoch(l, logFormat string, step int) string {
 			}
 		}
 		break
+	case "jsonl":
+		m := reJsonl.FindStringSubmatch(l)
+		if len(m) == 2 {
+			r = m[1]
+		}
 	}
 	if r == "" {
 		return ""

--- a/pkg/core/epoch_test.go
+++ b/pkg/core/epoch_test.go
@@ -34,20 +34,28 @@ func TestGetObjectKey(t *testing.T) {
 
 func TestParseEpoch(t *testing.T) {
 	etests := []struct {
-		desc string
-		in   string
-		out  string
+		desc      string
+		logFormat string
+		in        string
+		out       string
 	}{
-		{"base", "time:24/Feb/2017:10:00:07 +0900\thost:127.0.0.1", "20170224100000"},
-		{"just before begin carried", "time:24/Feb/2017:10:29:59 +0900\thost:127.0.0.1", "20170224100000"},
-		{"just after begin carried", "time:24/Feb/2017:10:30:00 +0900\thost:127.0.0.1", "20170224103000"},
-		{"time is after host", "host:127.0.0.1\ttime:24/Feb/2017:10:00:00 +0900", "20170224100000"},
-		{"time is closed in the bracket", "host:127.0.0.1\ttime:[24/Feb/2017:10:00:00 +0900]", "20170224100000"},
+		{"base", "tsv", "time:24/Feb/2017:10:00:07 +0900\thost:127.0.0.1", "20170224100000"},
+		{"just before begin carried", "tsv", "time:24/Feb/2017:10:29:59 +0900\thost:127.0.0.1", "20170224100000"},
+		{"just after begin carried", "tsv", "time:24/Feb/2017:10:30:00 +0900\thost:127.0.0.1", "20170224103000"},
+		{"time is after host", "tsv", "host:127.0.0.1\ttime:24/Feb/2017:10:00:00 +0900", "20170224100000"},
+		{"time is closed in the bracket", "tsv", "host:127.0.0.1\ttime:[24/Feb/2017:10:00:00 +0900]", "20170224100000"},
+
+		{"base", "jsonl", `{"time": "24/Feb/2017:10:00:07 +0900", "host": "127.0.0.1"}`, "20170224100000"},
+		{"just before begin carried", "jsonl", `{"time": "24/Feb/2017:10:29:59 +0900", "host": "127.0.0.1"}`, "20170224100000"},
+		{"just after begin carried", "jsonl", `{"time": "24/Feb/2017:10:30:00 +0900", "host": "127.0.0.1"}`, "20170224103000"},
+		{"time is after host", "jsonl", `{"host": "127.0.0.1", "time": "24/Feb/2017:10:00:00 +0900"}`, "20170224100000"},
+		{"no spacing", "jsonl", `{"host":"127.0.0.1","time":"24/Feb/2017:10:00:00 +0900"}`, "20170224100000"},
+		{"lots of spacing", "jsonl", `{"host"   :  "127.0.0.1",    "time"   :  "24/Feb/2017:10:00:00 +0900"  }`, "20170224100000"},
 	}
 	for _, tt := range etests {
-		s := parseEpoch(tt.in, "tsv", 30)
+		s := parseEpoch(tt.in, tt.logFormat, 30)
 		if s != tt.out {
-			t.Errorf("%q: parseEpoch(%q) => %s, wants %q", tt.desc, tt.in, s, tt.out)
+			t.Errorf("[%q] %q: parseEpoch(%q) => %s, wants %q", tt.logFormat, tt.desc, tt.in, s, tt.out)
 		}
 	}
 }


### PR DESCRIPTION
I'd like to handle `jsonl` (newline-delimitered JSON) format with `upload-log` command