### PR TITLE
Release by go 1.17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.17
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,7 +17,7 @@ archives:
     replacements:
       darwin: darwin
       linux: linux
-      386: i386
+      arm64: arm64
       amd64: x86_64
 release:
   prerelease: auto

--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,11 @@ bin/$(NAME): $(SRCS)
 .PHONY: cross-build
 cross-build:
 	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -a -tags netgo -installsuffix netgo $(LDFLAGS) -o dist/$(NAME)_darwin_amd64
-	GOOS=darwin GOARCH=386 CGO_ENABLED=0 go build -a -tags netgo -installsuffix netgo $(LDFLAGS) -o dist/$(NAME)_darwin_386
+	GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -a -tags netgo -installsuffix netgo $(LDFLAGS) -o dist/$(NAME)_darwin_arm64
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -tags netgo -installsuffix netgo $(LDFLAGS) -o dist/$(NAME)_linux_amd64
-	GOOS=linux GOARCH=386 CGO_ENABLED=0 go build -a -tags netgo -installsuffix netgo $(LDFLAGS) -o dist/$(NAME)_linux_386
+	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -a -tags netgo -installsuffix netgo $(LDFLAGS) -o dist/$(NAME)_linux_arm64
 	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -a -tags netgo -installsuffix netgo $(LDFLAGS) -o dist/$(NAME)_windows_amd64.exe
-	GOOS=windows GOARCH=386 CGO_ENABLED=0 go build -a -tags netgo -installsuffix netgo $(LDFLAGS) -o dist/$(NAME)_windows_386.exe
+	GOOS=windows GOARCH=arm64 CGO_ENABLED=0 go build -a -tags netgo -installsuffix netgo $(LDFLAGS) -o dist/$(NAME)_windows_arm64.exe
 
 .PHONY: test
 test:


### PR DESCRIPTION
## Why

- I released `v0.1.4`. then, goreleaser was abnormal termination.
  -  `release failed after 0.33s error=failed to build for darwin_amd64: exit status 2: flag provided but not defined: -a -tags netgo -installsuffix netgo`
  - https://github.com/hatena/u2s3/actions/runs/1469767422
- maybe, `netgo` isn't support go1.13 because go's newest versions is go1.17 and go1.13 isn't [stable version](https://golang.org/dl/)

## what changed

- release by go1.17 https://github.com/hatena/u2s3/commit/bf49501aacb5baafc7a7c244434cb692ef7daba5
- drop `386` arch and add `arm64` arch https://github.com/hatena/u2s3/commit/ee7d502ab36593c1a4b46f1693e7a2c9752f1e05
  - because `darwin/386` was dropped go.1.15 [ref](https://golang.org/doc/go1.15). I changed everything accordingly.

## tests

- I used go1.17.3 at hand and confirmed that `make cross-build` passed and` make test` passed.