### PR TITLE
fix can't release by goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,7 +6,9 @@ builds:
     binary: u2s3
     flags:
       - -trimpath
-      - -a -tags netgo -installsuffix netgo
+      - -a
+      - -tags=netgo
+      - -installsuffix=netgo
     ldflags:
       - -s -w -extldflags \"-static\"
       - -X github.com/hatena/u2s3/cli.version={{.Version}}


### PR DESCRIPTION
## why

- [Release by go 1.17 by do-su-0805 · Pull Request #16 · hatena/u2s3](https://github.com/hatena/u2s3/pull/16) I thought go1.13 was the cause of the release failure here, but that was a mistake.
- Actually, there was a problem with how to write `flags` in` .goreleaser.yml`.
  - see [How to correct pass build flags (-tags)? · Issue #810 · goreleaser/goreleaser](https://github.com/goreleaser/goreleaser/issues/810)

## what

- fix `.goreleaser.yml` 's flags .
  - separate by `-` and stick by `=`.

## tests

I have confirmed that `goreleaser release --snapshot --rm-dist` works at hand!

<details>
<summary> exec log </summary>

```
$ goreleaser release --snapshot --rm-dist
   • releasing...             
   • loading config file       file=.goreleaser.yml
   • loading environment variables
   • getting and validating git state
      • building...               commit=848d91a4fdb67bfeed5bb78dc784f1209b4bbefa latest tag=v0.1.5
      • pipe skipped              error=disabled during snapshot mode
   • parsing tag              
   • setting defaults         
      • snapshotting             
      • scm releases             
      • project name             
      • loading go mod information
      • building binaries        
      • universal binaries       
      • creating source archive  
      • archives                 
      • linux packages           
      • snapcraft packages       
      • calculating checksums    
      • signing artifacts        
      • signing docker images    
      • docker images            
      • docker manifests         
      • artifactory              
      • blobs                    
      • homebrew tap formula     
      • krew plugin manifest     
      • gofish fish food cookbook
      • scoop manifests          
      • discord                  
      • reddit                   
      • slack                    
      • teams                    
      • twitter                  
      • smtp                     
      • mattermost               
      • milestones               
      • linkedin                 
      • telegram                 
   • snapshotting             
      • building snapshot...      version=0.1.5-SNAPSHOT-848d91a
   • checking ./dist          
      • --rm-dist is set, cleaning it up
   • loading go mod information
   • writing effective config file
      • writing                   config=dist/config.yaml
   • building binaries        
      • building                  binary=/<path-to-u2s3>/dist/u2s3_darwin_arm64/u2s3
      • building                  binary=/<path-to-u2s3>/dist/u2s3_linux_arm64/u2s3
      • building                  binary=/<path-to-u2s3>/dist/u2s3_darwin_amd64/u2s3
      • building                  binary=/<path-to-u2s3>/dist/u2s3_linux_386/u2s3
      • building                  binary=/<path-to-u2s3>/dist/u2s3_linux_amd64/u2s3
   • archives                 
      • creating                  archive=dist/u2s3_linux_386.tar.gz
      • creating                  archive=dist/u2s3_darwin_x86_64.tar.gz
      • creating                  archive=dist/u2s3_linux_x86_64.tar.gz
      • creating                  archive=dist/u2s3_darwin_arm64.tar.gz
      • creating                  archive=dist/u2s3_linux_arm64.tar.gz
   • calculating checksums    
      • checksumming              file=u2s3_linux_x86_64.tar.gz
      • checksumming              file=u2s3_darwin_arm64.tar.gz
      • checksumming              file=u2s3_darwin_x86_64.tar.gz
      • checksumming              file=u2s3_linux_386.tar.gz
      • checksumming              file=u2s3_linux_arm64.tar.gz
   • release succeeded after 20.91s
```
</details>