### PR TITLE
appendix *breaking* information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * [Release by go 1.17 by do-su-0805 · Pull Request #16 · hatena/u2s3](https://github.com/hatena/u2s3/pull/16)
 
+### Breaking changes
+
+* Release binary packages format are tar.gz instead of raw binary now.
+
 ## v0.1.4 (2021-11-17) (not released)
 
 * [Add some test-cases for util.TestGetParams by Krout0n · Pull Request #13 · hatena/u2s3](https://github.com/hatena/u2s3/pull/13)


### PR DESCRIPTION
## Why

- Because of changing release system, Release packages format was changed. ( raw => `.tar.gz` ). It's breaking changes

## What

- add information for breaking changes to `CHANGELOG.md`

## If it approves

I wrote [Release pages of v0.1.5](https://github.com/hatena/u2s3/releases/tag/v0.1.5) manually